### PR TITLE
Add profit maximizing familiars

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "core-js": "^3.16.4",
+    "garbo-lib": "^0.0.6",
     "grimoire-kolmafia": "^0.3.26",
     "kolmafia": "^5.27690.0",
     "libram": "^0.8.24",

--- a/src/args.ts
+++ b/src/args.ts
@@ -44,6 +44,10 @@ export const args = Args.create(
         help: "Use your Space Jellyfish to get stench jellies during the war (this may reduce your goose familiar exp).",
         default: false,
       }),
+      profitFamiliar: Args.flag({
+        help: "Use free familiar turns for familiar related profits.",
+        default: false,
+      }),
       pvp: Args.flag({
         help: "Break your hippy stone at the start of the run.",
         default: false,

--- a/src/engine/outfit.ts
+++ b/src/engine/outfit.ts
@@ -307,7 +307,13 @@ export function equipDefaults(outfit: Outfit, noFightingFamiliars: boolean): voi
     if (profitFamiliar() === $familiar`Chest Mimic` && have($item`tiny stillsuit`)) outfit.equip($item`tiny stillsuit`);
   }
 
-  if (!noFightingFamiliars) outfit.equip($familiar`Jill-of-All-Trades`);
+  if (!noFightingFamiliars) {
+    if (args.minor.profitFamiliar) {
+      outfit.equip(profitFamiliar());
+      if (profitFamiliar() === $familiar`Chest Mimic` && have($item`tiny stillsuit`)) outfit.equip($item`tiny stillsuit`);
+    }
+    else outfit.equip($familiar`Jill-of-All-Trades`);
+  }
 
   outfit.equip($familiar`Blood-Faced Volleyball`); // default
 

--- a/src/engine/outfit.ts
+++ b/src/engine/outfit.ts
@@ -301,12 +301,13 @@ export function equipDefaults(outfit: Outfit, noFightingFamiliars: boolean): voi
   if (outfit.skipDefaults) return;
 
   if (modifier.includes("-combat")) outfit.equip($familiar`Disgeist`); // low priority
-  if (!noFightingFamiliars) outfit.equip($familiar`Jill-of-All-Trades`);
 
   if (args.minor.profitFamiliar) {
     outfit.equip(profitFamiliar());
     if (profitFamiliar() === $familiar`Chest Mimic` && have($item`tiny stillsuit`)) outfit.equip($item`tiny stillsuit`);
   }
+
+  if (!noFightingFamiliars) outfit.equip($familiar`Jill-of-All-Trades`);
 
   outfit.equip($familiar`Blood-Faced Volleyball`); // default
 

--- a/src/engine/outfit.ts
+++ b/src/engine/outfit.ts
@@ -109,11 +109,6 @@ const standardFamiliars: ValueFamiliar[] = [
       ) / 11, // 9 with blue plate
   },
   {
-    familiar: $familiar`Robortender`,
-    value: () =>
-      garboValue($item`elemental sugarcube`) / 5
-  },
-  {
     familiar: $familiar`Twitching Space Critter`,
 
     // Item is ludicrously overvalued and incredibly low-volume.

--- a/src/engine/outfit.ts
+++ b/src/engine/outfit.ts
@@ -6,36 +6,43 @@ import {
   outfit as equipOutfit,
   equippedAmount,
   equippedItem,
+  Familiar,
   familiarWeight,
+  holiday,
   Item,
   itemAmount,
   weaponHands as mafiaWeaponHands,
   myBasestat,
   myMeat,
   myTurncount,
+  numericModifier,
   outfitPieces,
   print,
   Skill,
   Slot,
   toSlot,
+  weightAdjustment,
 } from "kolmafia";
 import {
   $effect,
   $familiar,
   $familiars,
   $item,
+  $items,
   $skill,
   $slot,
   $slots,
   $stat,
+  clamp,
   DaylightShavings,
   get,
   have,
+  maxBy,
 } from "libram";
 import { Resource } from "./resources";
 import { Keys, keyStrategy } from "../tasks/keys";
 import { Modes, Outfit, OutfitSpec, step } from "grimoire-kolmafia";
-import { atLevel, haveLoathingLegion } from "../lib";
+import { atLevel, garboAverageValue, garboValue, haveLoathingLegion } from "../lib";
 import { args } from "../args";
 
 export function canEquipResource(outfit: Outfit, resource: Resource): boolean {
@@ -75,6 +82,115 @@ export function equipUntilCapped<T extends Resource>(outfit: Outfit, resources: 
     if (resource.chance && resource.chance() === 1) break;
   }
   return result;
+}
+
+type ValueFamiliar = {
+  familiar: Familiar;
+  value: () => number;
+};
+
+const standardFamiliars: ValueFamiliar[] = [
+  {
+    familiar: $familiar`Obtuse Angel`,
+    value: () => 0.02 * garboValue($item`time's arrow`),
+  },
+  {
+    familiar: $familiar`Stocking Mimic`,
+    value: () =>
+      garboAverageValue(...$items`Polka Pop, BitterSweetTarts, Piddles`) / 6 +
+      (1 / 3 + (have($effect`Jingle Jangle Jingle`) ? 0.1 : 0)) *
+      (familiarWeight($familiar`Stocking Mimic`) + weightAdjustment()),
+  },
+  {
+    familiar: $familiar`Shorter-Order Cook`,
+    value: () =>
+      garboAverageValue(
+        ...$items`short beer, short stack of pancakes, short stick of butter, short glass of water, short white`,
+      ) / 11, // 9 with blue plate
+  },
+  {
+    familiar: $familiar`Robortender`,
+    value: () =>
+      garboValue($item`elemental sugarcube`) / 5
+  },
+  {
+    familiar: $familiar`Twitching Space Critter`,
+
+    // Item is ludicrously overvalued and incredibly low-volume.
+    // We can remove this cap once the price reaches a lower equilibrium
+    // we probably won't, but we can.
+    value: () => Math.min(garboValue($item`twitching space egg`) * 0.0002, 690),
+  },
+  {
+    familiar: $familiar`Hobo Monkey`,
+    value: () => 75,
+  },
+  {
+    familiar: $familiar`Rockin' Robin`,
+    value: () =>
+      garboValue($item`robin's egg`) /
+      clamp(30 - get("rockinRobinProgress"), 1, 30),
+  },
+  {
+    familiar: $familiar`Optimistic Candle`,
+    value: () =>
+      garboValue($item`glob of melted wax`) /
+      clamp(30 - get("optimisticCandleProgress"), 1, 30),
+  },
+  {
+    familiar: $familiar`Garbage Fire`,
+    value: () =>
+      garboAverageValue(
+        ...$items`burning newspaper, extra-toasted half sandwich, mulled hobo wine`,
+      ) / clamp(30 - get("garbageFireProgress"), 1, 30),
+  },
+  {
+    familiar: $familiar`Cookbookbat`,
+    value: () =>
+      (3 *
+        garboAverageValue(
+          ...$items`Vegetable of Jarlsberg, Yeast of Boris, St. Sneaky Pete's Whey`,
+        )) /
+      11,
+  },
+  {
+    familiar: $familiar`Patriotic Eagle`,
+    value: () =>
+      holiday().includes("Dependence Day")
+        ? 0.05 * garboValue($item`souvenir flag`)
+        : 0,
+  },
+  {
+    familiar: $familiar`Chest Mimic`,
+    value: () => (get("valueOfAdventure") * get("garbo_embezzlerMultiplier", 2.68)) / 50 * (numericModifier("Familiar Exp") + 1)
+  },
+];
+
+
+function profitFamiliar(): Familiar {
+  return maxBy(standardFamiliars.filter(({ familiar }) => have(familiar)), ({ value }) => value()).familiar;
+}
+
+export function getModifiersFrom(outfit: OutfitSpec | Outfit | undefined): string {
+  if (!outfit?.modifier) return "";
+  if (Array.isArray(outfit.modifier)) return outfit.modifier.join(",");
+  return outfit.modifier;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function yellowSubmarinePossible(assumePulls = false) {
+  return false;
+  // if (!have($item`Powerful Glove`)) return false;
+  // if (!assumePulls && !have($item`Buddy Bjorn`)) return false;
+  // if (!have($familiar`Puck Man`) && !have($familiar`Ms. Puck Man`)) return false;
+  // if (
+  //   have($item`dingy dinghy`) ||
+  //   have($item`junk junk`) ||
+  //   have($item`skeletal skiff`) ||
+  //   have($item`yellow submarine`)
+  // )
+  //   return false;
+  // return true;
 }
 
 export function equipInitial(outfit: Outfit): void {
@@ -128,8 +244,8 @@ export function equipCharging(
 
   const need_bowling_balls =
     get("hiddenBowlingAlleyProgress") +
-      itemAmount($item`bowling ball`) +
-      closetAmount($item`bowling ball`) <
+    itemAmount($item`bowling ball`) +
+    closetAmount($item`bowling ball`) <
     5;
   const need_star_key =
     (itemAmount($item`star`) < 8 || itemAmount($item`line`) < 7) &&
@@ -186,6 +302,12 @@ export function equipDefaults(outfit: Outfit, noFightingFamiliars: boolean): voi
 
   if (modifier.includes("-combat")) outfit.equip($familiar`Disgeist`); // low priority
   if (!noFightingFamiliars) outfit.equip($familiar`Jill-of-All-Trades`);
+
+  if (args.minor.profitFamiliar) {
+    outfit.equip(profitFamiliar());
+    if (profitFamiliar() === $familiar`Chest Mimic` && have($item`tiny stillsuit`)) outfit.equip($item`tiny stillsuit`);
+  }
+
   outfit.equip($familiar`Blood-Faced Volleyball`); // default
 
   outfit.equip($item`mafia thumb ring`);
@@ -275,22 +397,6 @@ export function equipDefaults(outfit: Outfit, noFightingFamiliars: boolean): voi
   }
 
   outfit.equip($item`miniature crystal ball`);
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function yellowSubmarinePossible(assumePulls = false) {
-  return false;
-  // if (!have($item`Powerful Glove`)) return false;
-  // if (!assumePulls && !have($item`Buddy Bjorn`)) return false;
-  // if (!have($familiar`Puck Man`) && !have($familiar`Ms. Puck Man`)) return false;
-  // if (
-  //   have($item`dingy dinghy`) ||
-  //   have($item`junk junk`) ||
-  //   have($item`skeletal skiff`) ||
-  //   have($item`yellow submarine`)
-  // )
-  //   return false;
-  // return true;
 }
 
 export function fixFoldables(outfit: Outfit) {
@@ -542,9 +648,3 @@ export const stenchPlanner = new ElementalPlanner([
     modes: { parka: "dilophosaur" },
   },
 ]);
-
-export function getModifiersFrom(outfit: OutfitSpec | Outfit | undefined): string {
-  if (!outfit?.modifier) return "";
-  if (Array.isArray(outfit.modifier)) return outfit.modifier.join(",");
-  return outfit.modifier;
-}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,6 +1,7 @@
 import { step } from "grimoire-kolmafia";
 import {
   appearanceRates,
+  Item,
   Location,
   Monster,
   myFamiliar,
@@ -11,6 +12,7 @@ import {
   visitUrl,
 } from "kolmafia";
 import { $familiar, $item, $location, $monsters, $stat, get, have, Snapper } from "libram";
+import { makeValue, ValueFunctions } from "garbo-lib";
 
 export function debug(message: string, color?: string): void {
   if (color) {
@@ -121,4 +123,22 @@ export function primestatId(): number {
 
 export function cosmicBowlingBallReady() {
   return have($item`cosmic bowling ball`) || get("cosmicBowlingBallReturnCombats") === 0;
+}
+
+let _valueFunctions: ValueFunctions | undefined = undefined;
+function garboValueFunctions(): ValueFunctions {
+  if (!_valueFunctions) {
+    _valueFunctions = makeValue({
+      itemValues: new Map([[$item`fake hand`, 50000]]),
+    });
+  }
+  return _valueFunctions;
+}
+
+export function garboValue(item: Item, useHistorical = false): number {
+  return garboValueFunctions().value(item, useHistorical);
+}
+
+export function garboAverageValue(...items: Item[]): number {
+  return garboValueFunctions().averageValue(...items);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2013,6 +2013,11 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+garbo-lib@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/garbo-lib/-/garbo-lib-0.0.6.tgz#e657b73fa004ba83b60ba351995ba87d22dfd1b2"
+  integrity sha512-OHRQR4pIM90AMTUbdCx81A8TMV43SWXCMTYbIg8jEbxOlCU4BlomoWQTPYLn7FsmaxTl5q88uVVi6KJo4gLfYg==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"


### PR DESCRIPTION
Adds a pref to choose a familiar for profit maximization on 'free' turns. This then would determine what familiars you have, and which will yield maximum profit on turns that aren't important familiar turns.

In theory this will charge up mimic, in practice it may charge many things.